### PR TITLE
Reduce load on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,40 +17,35 @@ addons:
     - libmono-system-runtime-interopservices-runtimeinformation4.0-cil
 matrix:
   include:
-  - jdk: oraclejdk11
-    # See https://github.com/travis-ci/travis-ci/issues/8667
-    install: true
-    script:
-    - mvn clean jacoco:prepare-agent install jacoco:report
-    after_success:
-    - bash <(curl -s https://codecov.io/bash)
-    deploy:
-    - provider: bintray
-      file: bintray_info_maven.JSON
-      user: incplusplus
-      key: "$bintray_key"
-      skip_cleanup: true
-      on:
-        repo: IncPlusPlus/bigtoolbox-network
-        branch: master
-    - provider: releases
-      api_key:
-        secure: mDXAQIz8/BzrHerP2sS+xLHQpH+Be8uXNFAyCAIiQ17dkaznbCdOzm4n2DpDBQRLSKLch+KkKxaG+ZLaQ8TKlkK30twOg1L6g5S7VYXOqoCfsHMwVb3xKAsSUozUxEjTpIbZYG7QP//hJo6YPw7vLgk11bWQ3tB+2K6AeLFgiQDBRpOJfTO9nUujI1Lzh5Akaj/ihIXAFcfxix8RGZauvyAHzY5+Z4I8aCnq/mPM68SqWze4Udvg7//0wVJkYz1lCqXZZ2WwexLmaBSfTD+vnFQ8FfMjteNKbjx6cswnM709SyfFbyZx2cqW+IB9TH18HzJ+dlJJDJs04SK7v0gc9sb6wA8fXCmDDejhYVBIwI0ADOXI4EGaM9TmSvjLUC/mdIjM3kSupB4qQVdPwGeAaiX7m1OV6VJUfc+F6OTFPsEdt1UPLQH71Bk+0pgz2XSdA3ozJFJWAF6reQT6+kk598nEKyZ+2dtt6SE9dhV9eGLqo8QpPXirJJJ6iB160XorbwPM7ffSULNYHqiQV8Cvxh9Pyhg0LN61IAn0sobn6/x4tnhbdCEb4qKKqukxZm8nycE30zKN8PsTI7zVummYABhTAcMXQLiFgYYpHFWQzNQ5QIME8ny7/waCoIT8rSCBHo+q3QlAuWv1Juv6X34GUy4r6hZjFhh+oqm/IVQXaHU=
-      file_glob: true
-      file: target/bigtoolbox-network-*.*.*.jar
-      skip_cleanup: true
-      prerelease: true
-      on:
-        repo: IncPlusPlus/bigtoolbox-network
-        branch: master
-        tags: true
   - jdk: openjdk11
     # See https://github.com/travis-ci/travis-ci/issues/8667
     install: true
     before_script:
-    - 'curl -H ''Cache-Control: no-cache'' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh
-      | sudo bash'
+      - 'curl -H ''Cache-Control: no-cache'' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh
+        | sudo bash'
     script:
-    - mvn clean install
-    - fossa init
-    - fossa analyze
+      - mvn clean jacoco:prepare-agent install jacoco:report
+      - fossa init
+      - fossa analyze
+    after_success:
+      - bash <(curl -s https://codecov.io/bash)
+deploy:
+  - provider: bintray
+    file: bintray_info_maven.JSON
+    user: incplusplus
+    key: "$bintray_key"
+    skip_cleanup: true
+    on:
+      repo: IncPlusPlus/bigtoolbox-network
+      branch: master
+  - provider: releases
+    api_key:
+      secure: mDXAQIz8/BzrHerP2sS+xLHQpH+Be8uXNFAyCAIiQ17dkaznbCdOzm4n2DpDBQRLSKLch+KkKxaG+ZLaQ8TKlkK30twOg1L6g5S7VYXOqoCfsHMwVb3xKAsSUozUxEjTpIbZYG7QP//hJo6YPw7vLgk11bWQ3tB+2K6AeLFgiQDBRpOJfTO9nUujI1Lzh5Akaj/ihIXAFcfxix8RGZauvyAHzY5+Z4I8aCnq/mPM68SqWze4Udvg7//0wVJkYz1lCqXZZ2WwexLmaBSfTD+vnFQ8FfMjteNKbjx6cswnM709SyfFbyZx2cqW+IB9TH18HzJ+dlJJDJs04SK7v0gc9sb6wA8fXCmDDejhYVBIwI0ADOXI4EGaM9TmSvjLUC/mdIjM3kSupB4qQVdPwGeAaiX7m1OV6VJUfc+F6OTFPsEdt1UPLQH71Bk+0pgz2XSdA3ozJFJWAF6reQT6+kk598nEKyZ+2dtt6SE9dhV9eGLqo8QpPXirJJJ6iB160XorbwPM7ffSULNYHqiQV8Cvxh9Pyhg0LN61IAn0sobn6/x4tnhbdCEb4qKKqukxZm8nycE30zKN8PsTI7zVummYABhTAcMXQLiFgYYpHFWQzNQ5QIME8ny7/waCoIT8rSCBHo+q3QlAuWv1Juv6X34GUy4r6hZjFhh+oqm/IVQXaHU=
+    file_glob: true
+    file: target/bigtoolbox-network-*.*.*.jar
+    skip_cleanup: true
+    prerelease: true
+    on:
+      repo: IncPlusPlus/bigtoolbox-network
+      branch: master
+      tags: true


### PR DESCRIPTION
There isn't a need to run a build against OracleJDK and OpenJDK. This PR has us just use OpenJDK.